### PR TITLE
feat: script to setup ECU (fix libtracetool reference setting for pcl…

### DIFF
--- a/scripts/setup_ecu.bash
+++ b/scripts/setup_ecu.bash
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+fix_rclcpp_for_library () {
+    pcl_ros_cmake="/opt/ros/humble/share/pcl_ros/cmake/export_pcl_rosExport.cmake"
+    if [ -f $pcl_ros_cmake ]; then
+        sudo cp $pcl_ros_cmake $pcl_ros_cmake".bak"
+        sudo sed -i -e 's/\/opt\/ros\/humble\/lib\/libtracetools.so;//g' $pcl_ros_cmake
+    fi
+}
+
+fix_rclcpp_for_library


### PR DESCRIPTION
…_ros)

Signed-off-by: takeshi.iwanari <takeshi.iwanari@tier4.jp>

# Why this change is needed

- To solve https://github.com/tier4/caret/issues/56 at field environment
- Normal user working at office can run the following commands to handle the issue
    ```
    source ~/ros2_caret_ws/install/local_setup.bash
    colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=Off -DCMAKE_CXX_FLAGS="-w"
    ```
- However, when we work at field environment like car, it becomes difficult to run these commands. and it will be handy to have scripts for it

# Considerations

- This repository may be inappropriate to contain such scripts, but I'd like to commit this scripts for now because we download this repository when using CARET
- Other settings (e.g. scripts to modify tmux script, autoware.env) will be added in the future

