### PR TITLE
feat: add tracepoint for light record

### DIFF
--- a/launch/caret.launch.py
+++ b/launch/caret.launch.py
@@ -27,6 +27,7 @@ def generate_launch_description():
 						"ros2:dispatch*",
 						"ros2:rclcpp*",
 						"ros2:rcl_*init",
+						"ros2:rmw_take",
 						"*callback_group*",
 						"ros2_caret:*callback*",
 						"ros2_caret:dispatch*",


### PR DESCRIPTION
## Description

- `ros2:dispatch_subscription_callback` trace point is replaced with `ros2:rmw_take` by https://github.com/tier4/CARET_trace/pull/113.
- This PR adds `ros2:rmw_take` to light option filter

## Related links

https://tier4.atlassian.net/browse/RT2-725

## Notes for reviewers

- This PR can be merged prior to https://github.com/tier4/CARET_trace/pull/113 
- Confirmation results: https://github.com/tier4/CARET_trace/pull/113#pullrequestreview-1452073035

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
