### PR TITLE
feat: update tracepoint for iron light record

### DIFF
--- a/launch/caret.launch.py
+++ b/launch/caret.launch.py
@@ -2,6 +2,7 @@
 import launch
 from tracetools_launch.action import Trace
 
+import os
 import sys
 import datetime
 from distutils.util import strtobool
@@ -37,6 +38,8 @@ def generate_launch_description():
 						"ros2_caret:*executor",
 						"ros2_caret:dds_bind*",
 						]
+		if os.environ["ROS_DISTRO"] in ["iron", "rolling"]:
+			caret_event.append("ros2:rcl_publish")
 
 	if caret_session == "":
 		dt_now = datetime.datetime.now()


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- In ros2/rclcpp, rclcpp_publish does not have a publisher_handle
- This PR adds ros2:rcl_publish to light option filter when ROS2 DISTRIBUTION is after iron

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
- https://tier4.atlassian.net/browse/RT2-298
- https://github.com/tier4/CARET_analyze/pull/318
- https://github.com/tier4/CARET_trace/pull/150
- https://github.com/tier4/ros2caret/pull/86

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/tier4/caret/blob/main/.github/CONTRIBUTING.md).
- [x] The PR is ready for review.

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR has been properly tested.
- [x] The PR has been reviewed.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.
